### PR TITLE
Adds host param to OpenCopilot

### DIFF
--- a/examples/llm_copilot/copilot.py
+++ b/examples/llm_copilot/copilot.py
@@ -12,6 +12,7 @@ load_dotenv()
 copilot = OpenCopilot(
     prompt_file="prompts/prompt_template.txt",
     copilot_name="llm",
+    host=os.getenv("HOST"),
     auth_type=os.getenv("AUTH_TYPE"),
     weaviate_url=os.getenv("WEAVIATE_URL"),
     helicone_api_key=os.getenv("HELICONE_API_KEY"),
@@ -50,4 +51,4 @@ def load_helicone_docs() -> List[Document]:
     documents = loader.load()
     return _chunk_documents(documents)
 
-copilot(host=os.getenv("HOST"))
+copilot()

--- a/examples/llm_copilot/copilot.py
+++ b/examples/llm_copilot/copilot.py
@@ -50,4 +50,4 @@ def load_helicone_docs() -> List[Document]:
     documents = loader.load()
     return _chunk_documents(documents)
 
-copilot()
+copilot(host=os.getenv("HOST"))

--- a/opencopilot/application.py
+++ b/opencopilot/application.py
@@ -74,7 +74,7 @@ class OpenCopilot:
         self.local_file_paths = []
         self.documents = []
 
-    def __call__(self, *args, **kwargs):
+    def __call__(self, host: str = "127.0.0.1", *args, **kwargs):
         from .repository.documents import document_loader
         from .repository.documents import document_store
         from opencopilot.repository.documents.document_store import (
@@ -102,7 +102,7 @@ class OpenCopilot:
 
         from .app import app
 
-        uvicorn.run(app, port=self.api_port)
+        uvicorn.run(app, host=host, port=self.api_port)
 
     @staticmethod
     def add_prompt(prompt_file: str) -> bool:

--- a/opencopilot/application.py
+++ b/opencopilot/application.py
@@ -17,6 +17,7 @@ class OpenCopilot:
         prompt_file: str,
         openai_api_key: Optional[str] = None,
         copilot_name: str = "default",
+        host: str = "127.0.0.1",
         api_base_url: str = "http://127.0.0.1/",
         api_port: int = 3000,
         environment: str = "local",
@@ -46,6 +47,7 @@ class OpenCopilot:
             Settings(
                 OPENAI_API_KEY=openai_api_key,
                 COPILOT_NAME=copilot_name,
+                HOST=host,
                 API_PORT=api_port,
                 API_BASE_URL=api_base_url,
                 ENVIRONMENT=environment,
@@ -68,13 +70,14 @@ class OpenCopilot:
         )
 
         assert self.add_prompt(prompt_file), "Valid prompt file is required"
+        self.host = host
         self.api_port = api_port
         self.data_loaders = []
         self.local_files_dirs = []
         self.local_file_paths = []
         self.documents = []
 
-    def __call__(self, host: str = "127.0.0.1", *args, **kwargs):
+    def __call__(self, *args, **kwargs):
         from .repository.documents import document_loader
         from .repository.documents import document_store
         from opencopilot.repository.documents.document_store import (
@@ -102,7 +105,7 @@ class OpenCopilot:
 
         from .app import app
 
-        uvicorn.run(app, host=host, port=self.api_port)
+        uvicorn.run(app, host=self.host, port=self.api_port)
 
     @staticmethod
     def add_prompt(prompt_file: str) -> bool:

--- a/opencopilot/settings.py
+++ b/opencopilot/settings.py
@@ -14,6 +14,7 @@ from omegaconf import OmegaConf
 class Settings:
     COPILOT_NAME: str
 
+    HOST: str
     API_PORT: int
     API_BASE_URL: str
     ENVIRONMENT: str

--- a/tests/unit/authorization/test_create_access_token.py
+++ b/tests/unit/authorization/test_create_access_token.py
@@ -24,6 +24,7 @@ def test_execute_invalid_credentials(mock_settings):
 def test_execute_valid_credentials(mock_time, mock_settings):
     settings.get.return_value = Settings(
         COPILOT_NAME="unit_tests",
+        HOST="127.0.0.1",
         API_PORT=3000,
         API_BASE_URL="http://localhost:3000/",
         ENVIRONMENT="test",

--- a/tests/unit/authorization/test_validate_api_key_use_case.py
+++ b/tests/unit/authorization/test_validate_api_key_use_case.py
@@ -38,6 +38,7 @@ async def test_execute_bearer_api_key(mock_validate_jwt, mock_settings):
 async def test_validate_jwt_success(mock_jwt, mock_settings):
     settings.get.return_value = Settings(
         COPILOT_NAME="unit_tests",
+        HOST="127.0.0.1",
         API_PORT=3000,
         API_BASE_URL="http://localhost:3000/",
         ENVIRONMENT="test",

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -12,6 +12,7 @@ def pytest_sessionstart(session):
     """
     settings.set(Settings(
         COPILOT_NAME="unit_tests",
+        HOST="127.0.0.1",
         API_PORT=3000,
         API_BASE_URL="http://localhost:3000/",
         ENVIRONMENT="test",


### PR DESCRIPTION
### Task / problem
Hosting a copilot in a docker container is currently difficult without tricks since it's only running the API on `127.0.0.1`

### Changes made
Added `host` param

### Testing
Run the copilot
