### PR TITLE
Prompt validation

### DIFF
--- a/opencopilot/application.py
+++ b/opencopilot/application.py
@@ -69,7 +69,7 @@ class OpenCopilot:
             )
         )
 
-        assert self.add_prompt(prompt_file), "Valid prompt file is required"
+        self.add_prompt(prompt_file)
         self.host = host
         self.api_port = api_port
         self.data_loaders = []
@@ -108,8 +108,8 @@ class OpenCopilot:
         uvicorn.run(app, host=self.host, port=self.api_port)
 
     @staticmethod
-    def add_prompt(prompt_file: str) -> bool:
-        return settings.init_prompt_file_location(prompt_file)
+    def add_prompt(prompt_file: str):
+        settings.init_prompt_file_location(prompt_file)
 
     def data_loader(self, function: Callable[[], Document]):
         self.data_loaders.append(function)

--- a/opencopilot/settings.py
+++ b/opencopilot/settings.py
@@ -3,11 +3,8 @@ import os
 from dataclasses import dataclass
 from typing import Literal
 from typing import Optional
-from typing import Union
-
-from omegaconf import DictConfig
-from omegaconf import ListConfig
 from omegaconf import OmegaConf
+from opencopilot.utils.validators import validate_system_prompt
 
 
 @dataclass(frozen=False)
@@ -107,13 +104,11 @@ def init_custom_loaders(config_file: str) -> None:
             pass
 
 
-def init_prompt_file_location(file_path: str) -> bool:
+def init_prompt_file_location(file_path: str):
     settings = get()
     if settings:
-        if os.path.isfile(file_path):
-            settings.PROMPT_FILE = file_path
-            return True
-    return False
+        validate_system_prompt(file_path)
+        settings.PROMPT_FILE = file_path
 
 
 _settings: Optional[Settings] = None

--- a/opencopilot/utils/validators.py
+++ b/opencopilot/utils/validators.py
@@ -9,5 +9,7 @@ def validate_system_prompt(file_path: str):
                 raise Exception(f"'{{question}}' is missing in '{file_path}' prompt.")
             if not "{history}" in prompt:
                 raise Exception(f"'{{history}}' is missing in '{file_path}' prompt.")
+            if not "{context}" in prompt:
+                raise Exception(f"'{{context}}' is missing in '{file_path}' prompt.")
     else:
         raise Exception(f"'{file_path}' is not a file path.")

--- a/opencopilot/utils/validators.py
+++ b/opencopilot/utils/validators.py
@@ -1,0 +1,13 @@
+import os
+
+
+def validate_system_prompt(file_path: str):
+    if os.path.isfile(file_path):
+        with open(file_path, "r") as f:
+            prompt = f.read()
+            if not "{question}" in prompt:
+                raise Exception(f"'{{question}}' is missing in '{file_path}' prompt.")
+            if not "{history}" in prompt:
+                raise Exception(f"'{{history}}' is missing in '{file_path}' prompt.")
+    else:
+        raise Exception(f"'{file_path}' is not a file path.")


### PR DESCRIPTION
### Task / problem
Empty prompt file causes opencopilot to do... well... nothing.

### Changes made
Added prompt validation upon loading - checks for mandatory `{question}` and `{history}` fields

### Testing
Try creating a copilot with an empty prompt file.
