### PR TITLE
Get`source` field from doc metadata by default

### DIFF
--- a/opencopilot/repository/documents/document_store.py
+++ b/opencopilot/repository/documents/document_store.py
@@ -56,7 +56,7 @@ class WeaviateDocumentStore(DocumentStore):
 
     def _get_vector_store(self):
         metadatas = [d.metadata for d in self.documents]
-        attributes = list(metadatas[0].keys()) if metadatas else ['source']
+        attributes = list(metadatas[0].keys()) if metadatas else ["source"]
         return Weaviate(
             self.weaviate_client,
             index_name=self.weaviate_index_name,

--- a/opencopilot/repository/documents/document_store.py
+++ b/opencopilot/repository/documents/document_store.py
@@ -56,7 +56,7 @@ class WeaviateDocumentStore(DocumentStore):
 
     def _get_vector_store(self):
         metadatas = [d.metadata for d in self.documents]
-        attributes = list(metadatas[0].keys()) if metadatas else None
+        attributes = list(metadatas[0].keys()) if metadatas else ['source']
         return Weaviate(
             self.weaviate_client,
             index_name=self.weaviate_index_name,


### PR DESCRIPTION
### Task / problem
Document store's `find` method doesn't return metadata if `documents` is empty.

### Changes made
Added `sources` as default metadata field to retrieve

### Testing
Call `find` without ingesting data first
