### PR TITLE
Fixes cached scraped documents loading

### DIFF
--- a/opencopilot/repository/documents/document_loader.py
+++ b/opencopilot/repository/documents/document_loader.py
@@ -67,7 +67,7 @@ def execute(
         elif file_path.endswith(".xls") or file_path.endswith(".xlsx"):
             loader = UnstructuredExcelLoader(file_path)
             new_documents = loader.load()
-        elif file_path.endswith(".json") and file_path.replace(data_dir, "").startswith(
+        elif file_path.endswith(".json") and os.path.basename(file_path).startswith(
             "serialized_documents_"
         ):
             with open(file_path, "r") as f:


### PR DESCRIPTION
### Task / problem
RPM and LLM copilots cache scraped documents into json files with `serialized_documents_` prefix.
Current document_loader fails to properly detect these files and loads them as random json, not setting proper `source` for each serialized document.


### Changes made
Fixed file pattern matching and removed obsolete code.

Before:
```
Retrieved document sources:
        https://docs.opencopilot.dev/improve/evaluation
        data/serialized_documents_openai_docs.json
        data/serialized_documents_fullstack_deeplearning.json
        data/serialized_documents_openai_docs.json
```

After:
```
Retrieved document sources:
        https://docs.opencopilot.dev/improve/evaluation
        https://www.promptingguide.ai/techniques/rag
        https://fullstackdeeplearning.com/llm-bootcamp/spring-2023/augmented-language-models/
        https://platform.openai.com/docs/guides/gpt-best-practices/strategy-provide-reference-text
```

### Testing
Check if retrieved documents have proper `source` set
