### PR TITLE
Fixes copilot config check

### DIFF
--- a/opencopilot/repository/documents/document_loader.py
+++ b/opencopilot/repository/documents/document_loader.py
@@ -74,9 +74,9 @@ def execute(
                 document_dicts = json.load(f)
             for document in document_dicts:
                 metadata = document["metadata"]
-                if metadata["source"] in settings.get().copilot_config.data.get(
-                    "ignore", []
-                ):
+                if settings.get().copilot_config and metadata[
+                    "source"
+                ] in settings.get().copilot_config.data.get("ignore", []):
                     continue
                 if "deprecated" in metadata["source"]:
                     if not is_loading_deprecated:

--- a/opencopilot/settings.py
+++ b/opencopilot/settings.py
@@ -67,6 +67,8 @@ class Settings:
         self.PROMPT_QUESTION_KEY = self._get_prompt_key("question_key") or "User"
         self.PROMPT_ANSWER_KEY = self._get_prompt_key("response_key") or "Copilot"
 
+        self.copilot_config = None
+
     def is_production(self):
         return self.ENVIRONMENT == "production"
 


### PR DESCRIPTION
### Task / problem
Cached document loading broken because of missing `copilot_config` init and `check`

### Changes made
Added `copilot_config` init and check

### Testing
Run copilot
