### PR TITLE
Allow adding prompt as string, not just file name (ENG-379)

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,22 +82,8 @@ If you have access to GPT-4, change `llm_model_name` to `gpt-4`.
 ```python
 from opencopilot import OpenCopilot
 
-copilot = OpenCopilot(
-    openai_api_key="your-openai-api-key",
-    llm_model_name="gpt-3.5-turbo-16k",
-    prompt_file="my_prompt.txt"
-    )
-
-# Run the copilot
-copilot()
-```
-See our docs on [Configuration](https://docs.opencopilot.dev/integrate/configuration) if you'd like to learn more about other configuration options.
-
-### 3. Create a prompt template
-In the same directory create a text file, for example `my_prompt.txt`, add the following:
-
-```txt
-Your are a Parrot Copilot. Your purpose is to repeat what the user says, but in a different wording.
+PROMPT = """
+You are a Parrot Copilot. Your purpose is to repeat what the user says, but in a different wording.
 
 =========
 {context}
@@ -106,11 +92,23 @@ Your are a Parrot Copilot. Your purpose is to repeat what the user says, but in 
 {history}
 User: {question}
 Parrot Copilot answer in Markdown:
+"""
+
+copilot = OpenCopilot(
+    openai_api_key="your-openai-api-key",
+    llm_model_name="gpt-3.5-turbo-16k",
+    prompt=PROMPT
+    )
+
+# Run the copilot
+copilot()
 ```
 
-The template variables will be filled at runtime; see our docs on [Prompting](https://docs.opencopilot.dev/improve/prompting) if you'd like to learn more.
+In the prompt, the template variables will be filled at runtime; see our docs on [Prompting](https://docs.opencopilot.dev/improve/prompting) if you'd like to learn more.
 
-### 4. Run the Copilot
+See our docs on [Configuration](https://docs.opencopilot.dev/integrate/configuration) if you'd like to learn more about other configuration options.
+
+### 3. Run the Copilot
 
 ```bash
 python copilot.py
@@ -118,7 +116,7 @@ python copilot.py
 
 Your minimal copilot is now running as an API service, at `localhost:3000` by default. To see the full API documentation, go to [interactive Swagger docs](http://localhost:3000/docs#/Chat/handle_conversation_v0_conversation__conversation_id__post).
 
-### 5. Chat with the Copilot
+### 4. Chat with the Copilot
 You can quickly test out and chat with your copilot using the command-line interface by running:
 
 ```bash

--- a/opencopilot/application.py
+++ b/opencopilot/application.py
@@ -15,7 +15,8 @@ from .settings import Settings
 class OpenCopilot:
     def __init__(
         self,
-        prompt_file: str,
+        prompt: Optional[str] = None,
+        prompt_file: Optional[str] = None,
         openai_api_key: Optional[str] = None,
         copilot_name: str = "default",
         host: str = "127.0.0.1",

--- a/opencopilot/application.py
+++ b/opencopilot/application.py
@@ -7,7 +7,10 @@ from typing import Optional
 import uvicorn
 from langchain.schema import Document
 
-from .utils.validators import validate_openai_api_key, validate_prompt_and_prompt_file_config
+from .utils.validators import (
+    validate_openai_api_key,
+    validate_prompt_and_prompt_file_config,
+)
 from . import settings
 from .settings import Settings
 
@@ -45,9 +48,7 @@ class OpenCopilot:
         validate_openai_api_key(openai_api_key)
         validate_prompt_and_prompt_file_config(prompt, prompt_file)
 
-        
         prompt = prompt or open(prompt_file, "r").read()
-
 
         settings.set(
             Settings(

--- a/opencopilot/application.py
+++ b/opencopilot/application.py
@@ -7,10 +7,9 @@ from typing import Optional
 import uvicorn
 from langchain.schema import Document
 
-from .utils.validators import validate_openai_api_key
+from .utils.validators import validate_openai_api_key, validate_prompt_and_prompt_file_config
 from . import settings
 from .settings import Settings
-from .domain.errors import PromptError
 
 
 class OpenCopilot:
@@ -43,23 +42,12 @@ class OpenCopilot:
         if not openai_api_key:
             openai_api_key = os.getenv("OPENAI_API_KEY")
 
-        if prompt and prompt_file:
-            raise PromptError(
-                "You can only pass either a prompt or a prompt_file argument, not both."
-            )
-        if not prompt and not prompt_file:
-            raise PromptError(
-                "You need to pass either a prompt or a prompt_file argument."
-            )
-        
-        if prompt_file and not os.path.isfile(prompt_file):
-            raise PromptError(
-                f"Prompt file '{prompt_file}' does not exist. Please make sure your prompt file path points to a file that exists."
-            )
+        validate_openai_api_key(openai_api_key)
+        validate_prompt_and_prompt_file_config(prompt, prompt_file)
+
         
         prompt = prompt or open(prompt_file, "r").read()
 
-        validate_openai_api_key(openai_api_key)
 
         settings.set(
             Settings(

--- a/opencopilot/application.py
+++ b/opencopilot/application.py
@@ -10,6 +10,7 @@ from langchain.schema import Document
 from .utils.validators import (
     validate_openai_api_key,
     validate_prompt_and_prompt_file_config,
+    validate_system_prompt,
 )
 from . import settings
 from .settings import Settings
@@ -49,6 +50,7 @@ class OpenCopilot:
         validate_prompt_and_prompt_file_config(prompt, prompt_file)
 
         prompt = prompt or open(prompt_file, "r").read()
+        validate_system_prompt(prompt)
 
         settings.set(
             Settings(

--- a/opencopilot/domain/chat/utils.py
+++ b/opencopilot/domain/chat/utils.py
@@ -31,5 +31,4 @@ def add_history(
 
 
 def get_system_message() -> str:
-    with open(settings.get().PROMPT_FILE, "r") as f:
-        return f.read()
+    return settings.get().PROMPT

--- a/opencopilot/settings.py
+++ b/opencopilot/settings.py
@@ -4,7 +4,7 @@ from dataclasses import dataclass
 from typing import Literal
 from typing import Optional
 from omegaconf import OmegaConf
-from opencopilot.utils.validators import validate_system_prompt_file
+from opencopilot.utils.validators import validate_system_prompt
 
 
 @dataclass(frozen=False)
@@ -46,7 +46,7 @@ class Settings:
     MAX_CONTEXT_DOCUMENTS_COUNT: int = 4
     MAX_TOKEN_COUNT: int = 2048
 
-    PROMPT_FILE: Optional[str] = None
+    PROMPT: Optional[str] = None
 
     HELICONE_BASE_URL = "https://oai.hconeai.com/v1"
 
@@ -106,11 +106,11 @@ def init_custom_loaders(config_file: str) -> None:
             pass
 
 
-def init_prompt_file_location(file_path: str):
+def init_prompt(prompt: str):
     settings = get()
     if settings:
-        validate_system_prompt_file(file_path)
-        settings.PROMPT_FILE = file_path
+        validate_system_prompt(prompt)
+        settings.PROMPT = prompt
 
 
 _settings: Optional[Settings] = None

--- a/opencopilot/settings.py
+++ b/opencopilot/settings.py
@@ -4,7 +4,6 @@ from dataclasses import dataclass
 from typing import Literal
 from typing import Optional
 from omegaconf import OmegaConf
-from opencopilot.utils.validators import validate_system_prompt
 
 
 @dataclass(frozen=False)
@@ -109,7 +108,6 @@ def init_custom_loaders(config_file: str) -> None:
 def init_prompt(prompt: str):
     settings = get()
     if settings:
-        validate_system_prompt(prompt)
         settings.PROMPT = prompt
 
 

--- a/opencopilot/settings.py
+++ b/opencopilot/settings.py
@@ -4,7 +4,7 @@ from dataclasses import dataclass
 from typing import Literal
 from typing import Optional
 from omegaconf import OmegaConf
-from opencopilot.utils.validators import validate_system_prompt
+from opencopilot.utils.validators import validate_system_prompt_file
 
 
 @dataclass(frozen=False)
@@ -109,7 +109,7 @@ def init_custom_loaders(config_file: str) -> None:
 def init_prompt_file_location(file_path: str):
     settings = get()
     if settings:
-        validate_system_prompt(file_path)
+        validate_system_prompt_file(file_path)
         settings.PROMPT_FILE = file_path
 
 

--- a/opencopilot/utils/validators.py
+++ b/opencopilot/utils/validators.py
@@ -1,16 +1,6 @@
 import os
 from opencopilot.domain.errors import PromptError, APIKeyError
 
-def validate_system_prompt_file(file_path: str):
-    if not os.path.isfile(file_path):
-        raise PromptError(
-            f"Prompt file '{file_path}' does not exist. Please make sure your prompt file path points to a file that exists."
-        )
-
-    with open(file_path, "r") as f:
-        prompt = f.read()
-        validate_system_prompt(prompt)
-
 
 def validate_system_prompt(prompt: str):
     if not "{question}" in prompt:

--- a/opencopilot/utils/validators.py
+++ b/opencopilot/utils/validators.py
@@ -1,6 +1,21 @@
 import os
 from opencopilot.domain.errors import PromptError, APIKeyError
 
+def validate_prompt_and_prompt_file_config(prompt: str, prompt_file: str):
+    if prompt and prompt_file:
+        raise PromptError(
+            "You can only pass either a prompt or a prompt_file argument, not both."
+        )
+    if not prompt and not prompt_file:
+        raise PromptError(
+            "You need to pass either a prompt or a prompt_file argument."
+        )
+    
+    if prompt_file and not os.path.isfile(prompt_file):
+        raise PromptError(
+            f"Prompt file '{prompt_file}' does not exist. Please make sure your prompt file path points to a file that exists."
+        )
+
 
 def validate_system_prompt(prompt: str):
     if not "{question}" in prompt:

--- a/opencopilot/utils/validators.py
+++ b/opencopilot/utils/validators.py
@@ -1,16 +1,15 @@
 import os
 from opencopilot.domain.errors import PromptError, APIKeyError
 
+
 def validate_prompt_and_prompt_file_config(prompt: str, prompt_file: str):
     if prompt and prompt_file:
         raise PromptError(
             "You can only pass either a prompt or a prompt_file argument, not both."
         )
     if not prompt and not prompt_file:
-        raise PromptError(
-            "You need to pass either a prompt or a prompt_file argument."
-        )
-    
+        raise PromptError("You need to pass either a prompt or a prompt_file argument.")
+
     if prompt_file and not os.path.isfile(prompt_file):
         raise PromptError(
             f"Prompt file '{prompt_file}' does not exist. Please make sure your prompt file path points to a file that exists."
@@ -30,7 +29,6 @@ def validate_system_prompt(prompt: str):
         raise PromptError(
             f"Template variable '{{context}}' is missing in prompt. Please make sure your prompt file includes all required template variables."
         )
-        
 
 
 def validate_openai_api_key(key: str):

--- a/opencopilot/utils/validators.py
+++ b/opencopilot/utils/validators.py
@@ -1,27 +1,31 @@
 import os
 from opencopilot.domain.errors import PromptError, APIKeyError
 
-
-def validate_system_prompt(file_path: str):
-    if os.path.isfile(file_path):
-        with open(file_path, "r") as f:
-            prompt = f.read()
-            if not "{question}" in prompt:
-                raise PromptError(
-                    f"Template variable '{{question}}' is missing in prompt file '{file_path}'. Please make sure your prompt file includes all required template variables."
-                )
-            if not "{history}" in prompt:
-                raise PromptError(
-                    f"Template variable '{{history}}' is missing in prompt file '{file_path}'. Please make sure your prompt file includes all required template variables."
-                )
-            if not "{context}" in prompt:
-                raise PromptError(
-                    f"Template variable '{{context}}' is missing in prompt file '{file_path}'. Please make sure your prompt file includes all required template variables."
-                )
-    else:
+def validate_system_prompt_file(file_path: str):
+    if not os.path.isfile(file_path):
         raise PromptError(
             f"Prompt file '{file_path}' does not exist. Please make sure your prompt file path points to a file that exists."
         )
+
+    with open(file_path, "r") as f:
+        prompt = f.read()
+        validate_system_prompt(prompt)
+
+
+def validate_system_prompt(prompt: str):
+    if not "{question}" in prompt:
+        raise PromptError(
+            f"Template variable '{{question}}' is missing in prompt. Please make sure your prompt file includes all required template variables."
+        )
+    if not "{history}" in prompt:
+        raise PromptError(
+            f"Template variable '{{history}}' is missing in prompt. Please make sure your prompt file includes all required template variables."
+        )
+    if not "{context}" in prompt:
+        raise PromptError(
+            f"Template variable '{{context}}' is missing in prompt. Please make sure your prompt file includes all required template variables."
+        )
+        
 
 
 def validate_openai_api_key(key: str):

--- a/tests/unit/test_application.py
+++ b/tests/unit/test_application.py
@@ -8,6 +8,7 @@ from opencopilot.domain.errors import APIKeyError, ModelError, PromptError
 MOCK_OPENAI_API_KEY = "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"
 LLM_MODEL_NAME = "gpt-3.5-turbo-16k"
 VALID_PROMPT_FILE = "tests/assets/prompts/valid_prompt.txt"
+NO_USER_QUESTION_PROMPT_FILE = "tests/assets/prompts/no_user_question.txt"
 
 
 def test_openai_api_key_empty():
@@ -43,6 +44,35 @@ def test_prompt_file_valid():
 def test_prompt_file_invalid():
     with pytest.raises(PromptError):
         copilot = OpenCopilot(
-            prompt_file="tests/assets/prompts/no_user_question.txt",
+            prompt_file=NO_USER_QUESTION_PROMPT_FILE,
+            openai_api_key=MOCK_OPENAI_API_KEY,
+        )
+
+def test_prompt_string_valid():
+    copilot = OpenCopilot(
+        prompt=open(VALID_PROMPT_FILE, "r").read(),
+        openai_api_key=MOCK_OPENAI_API_KEY,
+    )
+
+
+def test_prompt_string_invalid():
+    with pytest.raises(PromptError):
+        copilot = OpenCopilot(
+            prompt=open(NO_USER_QUESTION_PROMPT_FILE, "r").read(),
+            openai_api_key=MOCK_OPENAI_API_KEY,
+        )
+
+
+def test_no_prompt_string_or_file_present():
+    with pytest.raises(PromptError):
+        copilot = OpenCopilot(
+            openai_api_key=MOCK_OPENAI_API_KEY,
+        )
+
+def test_both_prompt_string_and_file_present():
+    with pytest.raises(PromptError):
+        copilot = OpenCopilot(
+            prompt=open(VALID_PROMPT_FILE, "r").read(),
+            prompt_file=VALID_PROMPT_FILE,
             openai_api_key=MOCK_OPENAI_API_KEY,
         )


### PR DESCRIPTION
Related docs PR - **please review this simultaneously as this PR**
https://github.com/opencopilotdev/docs/pull/2

Commits
- validator for prompt file or prompt str
- add "prompt" constructor argument without breaking "prompt_file" constructor
- readme
- refactor: move validation into validators package
