### PR TITLE
Basic url loader that loads input urls without Javascript

### DIFF
--- a/opencopilot/application.py
+++ b/opencopilot/application.py
@@ -20,30 +20,30 @@ from .settings import Settings
 
 class OpenCopilot:
     def __init__(
-            self,
-            prompt: Optional[str] = None,
-            prompt_file: Optional[str] = None,
-            openai_api_key: Optional[str] = None,
-            copilot_name: str = "default",
-            host: str = "127.0.0.1",
-            api_base_url: str = "http://127.0.0.1/",
-            api_port: int = 3000,
-            environment: str = "local",
-            allowed_origins: str = "*",
-            application_name: str = "my-copilot",
-            log_file_path="./logs/logs.log",
-            weaviate_url: str = "http://localhost:8080/",
-            weaviate_read_timeout: int = 120,
-            llm_model_name: Literal["gpt-3.5-turbo-16k", "gpt-4"] = "gpt-4",
-            max_document_size_mb: int = 50,
-            slack_webhook: str = "",
-            auth_type: Optional[str] = None,
-            api_key: str = "",
-            jwt_client_id: str = "",
-            jwt_client_secret: str = "",
-            jwt_token_expiration_seconds: int = timedelta(days=1).total_seconds(),
-            helicone_api_key: str = "",
-            helicone_rate_limit_policy: str = "3;w=60;s=user",
+        self,
+        prompt: Optional[str] = None,
+        prompt_file: Optional[str] = None,
+        openai_api_key: Optional[str] = None,
+        copilot_name: str = "default",
+        host: str = "127.0.0.1",
+        api_base_url: str = "http://127.0.0.1/",
+        api_port: int = 3000,
+        environment: str = "local",
+        allowed_origins: str = "*",
+        application_name: str = "my-copilot",
+        log_file_path="./logs/logs.log",
+        weaviate_url: str = "http://localhost:8080/",
+        weaviate_read_timeout: int = 120,
+        llm_model_name: Literal["gpt-3.5-turbo-16k", "gpt-4"] = "gpt-4",
+        max_document_size_mb: int = 50,
+        slack_webhook: str = "",
+        auth_type: Optional[str] = None,
+        api_key: str = "",
+        jwt_client_id: str = "",
+        jwt_client_secret: str = "",
+        jwt_token_expiration_seconds: int = timedelta(days=1).total_seconds(),
+        helicone_api_key: str = "",
+        helicone_rate_limit_policy: str = "3;w=60;s=user",
     ):
         if not openai_api_key:
             openai_api_key = os.getenv("OPENAI_API_KEY")
@@ -98,10 +98,12 @@ class OpenCopilot:
         from opencopilot.repository.documents.document_store import EmptyDocumentStore
         from .src.utils.loaders import urls_loader
 
-        if (self.data_loaders
-                or self.local_files_dirs
-                or self.local_file_paths
-                or self.data_urls):
+        if (
+            self.data_loaders
+            or self.local_files_dirs
+            or self.local_file_paths
+            or self.data_urls
+        ):
             self.document_store = WeaviateDocumentStore()
         else:
             self.document_store = EmptyDocumentStore()
@@ -110,8 +112,7 @@ class OpenCopilot:
         text_splitter = self.document_store.get_text_splitter()
         for data_loader in self.data_loaders:
             documents = data_loader()
-            document_chunks = split_documents_use_case.execute(
-                text_splitter, documents)
+            document_chunks = split_documents_use_case.execute(text_splitter, documents)
             self.documents.extend(document_chunks)
 
         for data_dir in self.local_files_dirs:
@@ -120,9 +121,7 @@ class OpenCopilot:
             )
 
         if len(self.data_urls):
-            self.documents.extend(
-                urls_loader.execute(self.data_urls, text_splitter)
-            )
+            self.documents.extend(urls_loader.execute(self.data_urls, text_splitter))
 
         if self.documents:
             self.document_store.ingest_data(self.documents)

--- a/opencopilot/application.py
+++ b/opencopilot/application.py
@@ -140,7 +140,7 @@ class OpenCopilot:
     def add_local_files_dir(self, files_dir: str) -> None:
         self.local_files_dirs.append(files_dir)
 
-    def add_urls(self, urls: List[str]) -> None:
+    def add_data_urls(self, urls: List[str]) -> None:
         self.data_urls.extend(urls)
 
     # def add_local_file(self, file_path: str) -> None:

--- a/opencopilot/repository/documents/document_loader.py
+++ b/opencopilot/repository/documents/document_loader.py
@@ -10,12 +10,16 @@ from langchain.document_loaders import TextLoader
 from langchain.document_loaders import UnstructuredExcelLoader
 from langchain.document_loaders import UnstructuredFileLoader
 from langchain.schema import Document
+from langchain.text_splitter import TextSplitter
 
 from opencopilot import settings
+from opencopilot.repository.documents import split_documents_use_case
 
 
 def execute(
-    data_dir: str, is_loading_deprecated=False, text_splitter=None
+        data_dir: str,
+        is_loading_deprecated: bool,
+        text_splitter: TextSplitter
 ) -> List[Document]:
     files = []
     if not data_dir or not os.path.isdir(data_dir):
@@ -36,7 +40,7 @@ def execute(
     for file_path in files:
         new_documents = []
         if (
-            file_size := _get_file_size(file_path)
+                file_size := _get_file_size(file_path)
         ) > settings.get().MAX_DOCUMENT_SIZE_MB:
             print(
                 f"Document {file_path} too big ({file_size} > {settings.get().MAX_DOCUMENT_SIZE_MB}), skipping."
@@ -68,14 +72,14 @@ def execute(
             loader = UnstructuredExcelLoader(file_path)
             new_documents = loader.load()
         elif file_path.endswith(".json") and os.path.basename(file_path).startswith(
-            "serialized_documents_"
+                "serialized_documents_"
         ):
             with open(file_path, "r") as f:
                 document_dicts = json.load(f)
             for document in document_dicts:
                 metadata = document["metadata"]
                 if settings.get().copilot_config and metadata.get(
-                    "source"
+                        "source"
                 ) in settings.get().copilot_config.data.get("ignore", []):
                     continue
                 if "deprecated" in metadata.get("source", ""):
@@ -95,12 +99,8 @@ def execute(
             except Exception as e:
                 print(f"Error loading {file_path}")
         if text_splitter:
-            document_chunks = []
-            for document in new_documents:
-                for chunk in text_splitter.split_text(document.page_content):
-                    document_chunks.append(
-                        Document(page_content=chunk, metadata=document.metadata)
-                    )
+            document_chunks = split_documents_use_case.execute(
+                text_splitter, new_documents)
             print(
                 f"Generated {len(document_chunks)} document chunks from {len(new_documents)} documents"
             )

--- a/opencopilot/repository/documents/document_loader.py
+++ b/opencopilot/repository/documents/document_loader.py
@@ -17,9 +17,7 @@ from opencopilot.repository.documents import split_documents_use_case
 
 
 def execute(
-        data_dir: str,
-        is_loading_deprecated: bool,
-        text_splitter: TextSplitter
+    data_dir: str, is_loading_deprecated: bool, text_splitter: TextSplitter
 ) -> List[Document]:
     files = []
     if not data_dir or not os.path.isdir(data_dir):
@@ -40,7 +38,7 @@ def execute(
     for file_path in files:
         new_documents = []
         if (
-                file_size := _get_file_size(file_path)
+            file_size := _get_file_size(file_path)
         ) > settings.get().MAX_DOCUMENT_SIZE_MB:
             print(
                 f"Document {file_path} too big ({file_size} > {settings.get().MAX_DOCUMENT_SIZE_MB}), skipping."
@@ -72,14 +70,14 @@ def execute(
             loader = UnstructuredExcelLoader(file_path)
             new_documents = loader.load()
         elif file_path.endswith(".json") and os.path.basename(file_path).startswith(
-                "serialized_documents_"
+            "serialized_documents_"
         ):
             with open(file_path, "r") as f:
                 document_dicts = json.load(f)
             for document in document_dicts:
                 metadata = document["metadata"]
                 if settings.get().copilot_config and metadata.get(
-                        "source"
+                    "source"
                 ) in settings.get().copilot_config.data.get("ignore", []):
                     continue
                 if "deprecated" in metadata.get("source", ""):
@@ -100,7 +98,8 @@ def execute(
                 print(f"Error loading {file_path}")
         if text_splitter:
             document_chunks = split_documents_use_case.execute(
-                text_splitter, new_documents)
+                text_splitter, new_documents
+            )
             print(
                 f"Generated {len(document_chunks)} document chunks from {len(new_documents)} documents"
             )

--- a/opencopilot/repository/documents/document_store.py
+++ b/opencopilot/repository/documents/document_store.py
@@ -8,11 +8,8 @@ from langchain.text_splitter import TextSplitter
 from langchain.vectorstores import Weaviate
 
 from opencopilot import settings
-from opencopilot.logger import api_logger
 from opencopilot.utils import get_embedding_model_use_case
 from opencopilot.utils.get_embedding_model_use_case import CachedOpenAIEmbeddings
-
-logger = api_logger.get()
 
 
 class DocumentStore:
@@ -75,9 +72,9 @@ class WeaviateDocumentStore(DocumentStore):
         self.weaviate_client.schema.delete_all()
 
         for i in tqdm.tqdm(
-            range(0, int(len(documents) / batch_size) + 1), desc="Embedding.."
+                range(0, int(len(documents) / batch_size) + 1), desc="Embedding.."
         ):
-            batch = documents[i * batch_size : (i + 1) * batch_size]
+            batch = documents[i * batch_size: (i + 1) * batch_size]
             self.vector_store.add_documents(batch)
 
         self.embeddings.save_local_cache()

--- a/opencopilot/repository/documents/document_store.py
+++ b/opencopilot/repository/documents/document_store.py
@@ -72,9 +72,9 @@ class WeaviateDocumentStore(DocumentStore):
         self.weaviate_client.schema.delete_all()
 
         for i in tqdm.tqdm(
-                range(0, int(len(documents) / batch_size) + 1), desc="Embedding.."
+            range(0, int(len(documents) / batch_size) + 1), desc="Embedding.."
         ):
-            batch = documents[i * batch_size: (i + 1) * batch_size]
+            batch = documents[i * batch_size : (i + 1) * batch_size]
             self.vector_store.add_documents(batch)
 
         self.embeddings.save_local_cache()

--- a/opencopilot/repository/documents/split_documents_use_case.py
+++ b/opencopilot/repository/documents/split_documents_use_case.py
@@ -4,10 +4,7 @@ from langchain.schema import Document
 from langchain.text_splitter import TextSplitter
 
 
-def execute(
-        text_splitter: TextSplitter,
-        documents: List[Document]
-) -> List[Document]:
+def execute(text_splitter: TextSplitter, documents: List[Document]) -> List[Document]:
     document_chunks = []
     for document in documents:
         for chunk in text_splitter.split_text(document.page_content):

--- a/opencopilot/repository/documents/split_documents_use_case.py
+++ b/opencopilot/repository/documents/split_documents_use_case.py
@@ -1,0 +1,17 @@
+from typing import List
+
+from langchain.schema import Document
+from langchain.text_splitter import TextSplitter
+
+
+def execute(
+        text_splitter: TextSplitter,
+        documents: List[Document]
+) -> List[Document]:
+    document_chunks = []
+    for document in documents:
+        for chunk in text_splitter.split_text(document.page_content):
+            document_chunks.append(
+                Document(page_content=chunk, metadata=document.metadata)
+            )
+    return document_chunks

--- a/opencopilot/src/utils/loaders/urls_loader.py
+++ b/opencopilot/src/utils/loaders/urls_loader.py
@@ -1,0 +1,41 @@
+from typing import Dict
+from typing import List
+from typing import Optional
+
+import trafilatura
+from langchain.schema import Document
+from langchain.text_splitter import TextSplitter
+
+from opencopilot.logger import api_logger
+from opencopilot.repository.documents import split_documents_use_case
+
+logger = api_logger.get()
+
+
+def execute(urls: List[str], text_splitter: TextSplitter) -> List[Document]:
+    documents: List[Document] = []
+    for url in urls:
+        scraped_document = _scrape_html(url)
+        if scraped_document:
+            documents.append(scraped_document)
+    return split_documents_use_case.execute(text_splitter, documents)
+
+
+def _scrape_html(url) -> Optional[Document]:
+    try:
+        downloaded = trafilatura.fetch_url(url)
+        if not downloaded:
+            raise Exception()
+        text = trafilatura.extract(downloaded)
+        metadata: Dict = {
+            "source": url,
+        }
+        extracted_metadata = trafilatura.extract_metadata(downloaded)
+        if extracted_metadata and extracted_metadata.title:
+            metadata["title"] = extracted_metadata.title
+        return Document(
+            page_content=text,
+            metadata=metadata
+        )
+    except Exception as e:
+        logger.warning(f"Failed to scrape the contents from {url}")

--- a/opencopilot/src/utils/loaders/urls_loader.py
+++ b/opencopilot/src/utils/loaders/urls_loader.py
@@ -27,6 +27,8 @@ def _scrape_html(url) -> Optional[Document]:
         if not downloaded:
             raise Exception()
         text = trafilatura.extract(downloaded)
+        if not text:
+            raise Exception("Failed to extract text")
         metadata: Dict = {
             "source": url,
         }

--- a/opencopilot/src/utils/loaders/urls_loader.py
+++ b/opencopilot/src/utils/loaders/urls_loader.py
@@ -33,9 +33,6 @@ def _scrape_html(url) -> Optional[Document]:
         extracted_metadata = trafilatura.extract_metadata(downloaded)
         if extracted_metadata and extracted_metadata.title:
             metadata["title"] = extracted_metadata.title
-        return Document(
-            page_content=text,
-            metadata=metadata
-        )
+        return Document(page_content=text, metadata=metadata)
     except Exception as e:
         logger.warning(f"Failed to scrape the contents from {url}")

--- a/requirements.txt
+++ b/requirements.txt
@@ -26,7 +26,6 @@ openai==0.27.8
 wandb==0.15.4
 streamlit==1.24.0
 playwright==1.35.0
-unstructured==0.7.2
 dataclasses-json==0.5.9
 omegaconf==2.3.0
 GitPython==3.1.32
@@ -35,3 +34,4 @@ aiohttp==3.8.5
 xxhash==3.3.0
 openpyxl==3.1.2
 typer[all]==0.7.0
+trafilatura==1.6.1

--- a/setup.py
+++ b/setup.py
@@ -48,6 +48,7 @@ setup(
         'omegaconf',
         'openpyxl',
         'typer[all]',
+        'trafilatura',
     ],
     entry_points={
         'console_scripts': [

--- a/tests/unit/repository/documents/test_split_documents_use_case.py
+++ b/tests/unit/repository/documents/test_split_documents_use_case.py
@@ -1,0 +1,44 @@
+from unittest.mock import MagicMock
+
+from langchain.schema import Document
+
+from opencopilot.repository.documents import split_documents_use_case as use_case
+
+
+def _get_text_splitter():
+    splitter = MagicMock()
+    splitter.split_text.return_value = ["1", "2"]
+    return splitter
+
+
+def setup():
+    pass
+
+
+def test_success_maintains_metadata():
+    metadata = {
+        "source": "mock-source",
+        "title": "mock-title",
+        "random": "random-value",
+    }
+    documents = [
+        Document(
+            page_content="12",
+            metadata={
+                "source": "mock-source",
+                "title": "mock-title",
+                "random": "random-value",
+            }
+        )
+    ]
+    result = use_case.execute(_get_text_splitter(), documents)
+    assert result == [
+        Document(
+            page_content="1",
+            metadata=metadata,
+        ),
+        Document(
+            page_content="2",
+            metadata=metadata,
+        ),
+    ]


### PR DESCRIPTION
### Task / problem
Add basic URL scraping functionality

### Changes made
Added a new method to OpenCopilot:
```
copilot.add_urls(
    [
        "https://en.wikipedia.org/wiki/Estonian_identity_card",
        "https://aws.amazon.com/cli/",
        "https://randomurlherethatdoesnotexist.com"
    ]
)
```
That scrapes the contents of the url and loads to vector store
If url does not exist then logger gives a warning but app startup still succeeds.
*Does not support Javascript*

```
{"asctime": "2023-09-01 16:48:00,836", "name": "my-copilot", "levelname": "WARNING", "message": "Failed to scrape the contents from https://randomurlherethatdoesnotexist.com"}
```

### Testing
- Run local unit tests
- Call the function shown above before running the copilot and check the ingested data
