### PR TITLE
tp/cleanup

### DIFF
--- a/opencopilot/application.py
+++ b/opencopilot/application.py
@@ -80,7 +80,6 @@ class OpenCopilot:
             )
         )
 
-        self.add_prompt(prompt)
         self.host = host
         self.api_port = api_port
         self.data_loaders = []
@@ -88,6 +87,7 @@ class OpenCopilot:
         self.data_urls = []
         self.local_file_paths = []
         self.documents = []
+        settings.init_prompt(prompt)
 
     def __call__(self, *args, **kwargs):
         from .repository.documents import document_loader
@@ -129,10 +129,6 @@ class OpenCopilot:
         from .app import app
 
         uvicorn.run(app, host=self.host, port=self.api_port)
-
-    @staticmethod
-    def add_prompt(prompt: str):
-        settings.init_prompt(prompt)
 
     def data_loader(self, function: Callable[[], Document]):
         self.data_loaders.append(function)

--- a/opencopilot/application.py
+++ b/opencopilot/application.py
@@ -56,6 +56,7 @@ class OpenCopilot:
 
         settings.set(
             Settings(
+                PROMPT=prompt,
                 OPENAI_API_KEY=openai_api_key,
                 COPILOT_NAME=copilot_name,
                 HOST=host,
@@ -87,7 +88,7 @@ class OpenCopilot:
         self.data_urls = []
         self.local_file_paths = []
         self.documents = []
-        settings.init_prompt(prompt)
+    
 
     def __call__(self, *args, **kwargs):
         from .repository.documents import document_loader

--- a/opencopilot/application.py
+++ b/opencopilot/application.py
@@ -88,7 +88,6 @@ class OpenCopilot:
         self.data_urls = []
         self.local_file_paths = []
         self.documents = []
-    
 
     def __call__(self, *args, **kwargs):
         from .repository.documents import document_loader

--- a/opencopilot/repository/documents/document_loader.py
+++ b/opencopilot/repository/documents/document_loader.py
@@ -76,10 +76,6 @@ def execute(
                 document_dicts = json.load(f)
             for document in document_dicts:
                 metadata = document["metadata"]
-                if settings.get().copilot_config and metadata.get(
-                    "source"
-                ) in settings.get().copilot_config.data.get("ignore", []):
-                    continue
                 if "deprecated" in metadata.get("source", ""):
                     if not is_loading_deprecated:
                         # skip deprecated information

--- a/opencopilot/settings.py
+++ b/opencopilot/settings.py
@@ -90,12 +90,6 @@ class Settings:
         return None
 
 
-def init_data_dir(data_dir: str) -> None:
-    settings = get()
-    if settings:
-        settings.DATA_DIR = data_dir if os.path.exists(data_dir) else None
-
-
 _settings: Optional[Settings] = None
 
 

--- a/opencopilot/settings.py
+++ b/opencopilot/settings.py
@@ -61,8 +61,6 @@ class Settings:
         self.PROMPT_QUESTION_KEY = "User"
         self.PROMPT_ANSWER_KEY = "Copilot"
 
-        self.copilot_config = None
-
     def is_production(self):
         return self.ENVIRONMENT == "production"
 

--- a/opencopilot/settings.py
+++ b/opencopilot/settings.py
@@ -43,7 +43,6 @@ class Settings:
     # Configure based on model?
     PROMPT_HISTORY_INCLUDED_COUNT: int = 4
     MAX_CONTEXT_DOCUMENTS_COUNT: int = 4
-    MAX_TOKEN_COUNT: int = 2048
 
     PROMPT: Optional[str] = None
 

--- a/opencopilot/settings.py
+++ b/opencopilot/settings.py
@@ -48,8 +48,6 @@ class Settings:
 
     HELICONE_BASE_URL = "https://oai.hconeai.com/v1"
 
-    DATA_DIR: str = ""
-
     def __post_init__(self):
         os.environ["OPENAI_API_KEY"] = self.OPENAI_API_KEY
 

--- a/opencopilot/settings.py
+++ b/opencopilot/settings.py
@@ -105,12 +105,6 @@ def init_custom_loaders(config_file: str) -> None:
             pass
 
 
-def init_prompt(prompt: str):
-    settings = get()
-    if settings:
-        settings.PROMPT = prompt
-
-
 _settings: Optional[Settings] = None
 
 

--- a/opencopilot/settings.py
+++ b/opencopilot/settings.py
@@ -96,15 +96,6 @@ def init_data_dir(data_dir: str) -> None:
         settings.DATA_DIR = data_dir if os.path.exists(data_dir) else None
 
 
-def init_custom_loaders(config_file: str) -> None:
-    settings = get()
-    if settings:
-        try:
-            settings.copilot_config = OmegaConf.load(config_file)
-        except:
-            pass
-
-
 _settings: Optional[Settings] = None
 
 

--- a/opencopilot/settings.py
+++ b/opencopilot/settings.py
@@ -61,8 +61,6 @@ class Settings:
         ):
             self.AUTH_TYPE = None
 
-        self.COPILOT_DIRECTORY = f"copilots/{self.COPILOT_NAME}"
-
         self.PROMPT_QUESTION_KEY = "User"
         self.PROMPT_ANSWER_KEY = "Copilot"
 

--- a/opencopilot/settings.py
+++ b/opencopilot/settings.py
@@ -1,9 +1,7 @@
-import json
 import os
 from dataclasses import dataclass
 from typing import Literal
 from typing import Optional
-from omegaconf import OmegaConf
 
 
 @dataclass(frozen=False)

--- a/opencopilot/settings.py
+++ b/opencopilot/settings.py
@@ -63,8 +63,8 @@ class Settings:
 
         self.COPILOT_DIRECTORY = f"copilots/{self.COPILOT_NAME}"
 
-        self.PROMPT_QUESTION_KEY = self._get_prompt_key("question_key") or "User"
-        self.PROMPT_ANSWER_KEY = self._get_prompt_key("response_key") or "Copilot"
+        self.PROMPT_QUESTION_KEY = "User"
+        self.PROMPT_ANSWER_KEY = "Copilot"
 
         self.copilot_config = None
 
@@ -77,17 +77,6 @@ class Settings:
         if self.MODEL == "gpt-4":
             return 8192
         return 2048
-
-    def _get_prompt_key(self, key: str) -> Optional[str]:
-        try:
-            with open(
-                f"{self.COPILOT_DIRECTORY}/prompts/prompt_configuration.json", "r"
-            ) as f:
-                prompt_configuration = json.load(f)
-            return prompt_configuration.get(key) or None
-        except:
-            pass
-        return None
 
 
 _settings: Optional[Settings] = None


### PR DESCRIPTION
- refactor: rm unnecessary user-visible method
- rm unnecessary prompt init
- rm unused method
- rm unused method
- remove prompt question/answer key configurability - because we have deprecated this right now
- unused COPILOT_DIRECTORY setting
- unused MAX_TOKENS_COUNT setting
- unused DATA_DIR setting
- remove copilot_config setting that is never used, and related if-clause that is never entered
- rm unused imports
- linter
