### PR TITLE
Add openai_api_key named parameter for embeddings

### DIFF
--- a/opencopilot/utils/get_embedding_model_use_case.py
+++ b/opencopilot/utils/get_embedding_model_use_case.py
@@ -82,4 +82,5 @@ def execute(use_local_cache: bool = False):
         use_local_cache=use_local_cache,
         openai_api_base=openai_api_base,
         headers=headers,
+        openai_api_key=settings.get().OPENAI_API_KEY,
     )


### PR DESCRIPTION
### Task / problem
pydantic.error_wrappers.ValidationError: 1 validation error for CachedOpenAIEmbeddings
__root__
  Did not find openai_api_key, please add an environment variable `OPENAI_API_KEY` which contains it, or pass  `openai_api_key` as a named parameter. (type=value_error)
