### PR TITLE
Use embedded weaviate if weaviate url not specified, if weaviate url (ENG-382)

### DIFF
--- a/opencopilot/application.py
+++ b/opencopilot/application.py
@@ -30,7 +30,7 @@ class OpenCopilot:
         api_port: int = 3000,
         environment: str = "local",
         allowed_origins: str = "*",
-        weaviate_url: str = "http://localhost:8080/",
+        weaviate_url: Optional[str] = None,
         weaviate_read_timeout: int = 120,
         llm_model_name: Literal["gpt-3.5-turbo-16k", "gpt-4"] = "gpt-4",
         max_document_size_mb: int = 50,

--- a/opencopilot/repository/documents/document_store.py
+++ b/opencopilot/repository/documents/document_store.py
@@ -46,10 +46,19 @@ class WeaviateDocumentStore(DocumentStore):
         self.vector_store = self._get_vector_store()
 
     def _get_weaviate_client(self):
-        return weaviate.Client(
-            url=settings.get().WEAVIATE_URL,
-            timeout_config=(10, settings.get().WEAVIATE_READ_TIMEOUT),
-        )
+        if url := settings.get().WEAVIATE_URL:
+            return weaviate.Client(
+                url=url,
+                timeout_config=(10, settings.get().WEAVIATE_READ_TIMEOUT),
+            )
+        else:
+            return weaviate.Client(
+                timeout_config=(10, settings.get().WEAVIATE_READ_TIMEOUT),
+                embedded_options=weaviate.embedded.EmbeddedOptions(
+                    port=8080,
+                    hostname="localhost",
+                ),
+            )
 
     def _get_vector_store(self):
         metadatas = [d.metadata for d in self.documents]

--- a/opencopilot/settings.py
+++ b/opencopilot/settings.py
@@ -1,4 +1,3 @@
-import os
 from dataclasses import dataclass
 from typing import Literal
 from typing import Optional
@@ -14,7 +13,7 @@ class Settings:
     ENVIRONMENT: str
     ALLOWED_ORIGINS: str
 
-    WEAVIATE_URL: str
+    WEAVIATE_URL: Optional[str]
     WEAVIATE_READ_TIMEOUT: int
 
     MODEL: Literal["gpt-3.5-turbo-16k", "gpt-4"]

--- a/requirements.txt
+++ b/requirements.txt
@@ -11,7 +11,7 @@ pyjwt[crypto]===2.6.0
 Jinja2==3.1.2
 tiktoken==0.4.0
 text-generation==0.6.0
-weaviate-client==3.19.2
+weaviate-client==3.23.2
 pylint==2.17.5
 pytest==7.3.1
 pytest-cov==4.1.0

--- a/setup.py
+++ b/setup.py
@@ -38,7 +38,7 @@ setup(
         'Jinja2',
         'tiktoken',
         'text-generation',
-        'weaviate-client',
+        'weaviate-client>=3.23.2',
         'pypdf',
         'unstructured',
         'pdf2image',


### PR DESCRIPTION
…is specified connect to that url

Weaviate supports an embedded version as well that only works on macOS and linux. If weaviate_url not specified in constructor try to default to embedded version, if not specified then try to use url connection