### PR TITLE
bump gitpython vulnerable version

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -28,7 +28,7 @@ streamlit==1.24.0
 playwright==1.35.0
 dataclasses-json==0.5.9
 omegaconf==2.3.0
-GitPython==3.1.32
+GitPython==3.1.33
 pytesseract==0.3.10
 aiohttp==3.8.5
 xxhash==3.3.0


### PR DESCRIPTION
Addresses:
* https://github.com/opencopilotdev/opencopilot/security/dependabot/5
* https://github.com/opencopilotdev/opencopilot/security/dependabot/6