### PR TITLE
Installs specific llama-cpp-python version

### DIFF
--- a/.github/workflows/e2e_test_oss_llm.yml
+++ b/.github/workflows/e2e_test_oss_llm.yml
@@ -2,7 +2,7 @@ name: E2E Test OSS LLM
 
 on:
   push:
-    branches: [ main, ci-oss-llm ]
+    branches: [ main, kresimir/fix-oss-llm-ci ]
 
 jobs:
   e2e-test-oss-llm:
@@ -19,7 +19,7 @@ jobs:
       - name: "Install requirements"
         run: |
           pip install -r requirements.txt
-          pip install llama-cpp-python
+          pip install llama-cpp-python==0.1.83
           pip install -e .
       - name: "Setup env"
         run: |


### PR DESCRIPTION
### Task / problem
The OSS LLM CI is failing due to a faulty release of `llama-cpp-python`.

### Changes made
Locked the `llama-cpp-python` to its previous working version.

### Testing
Run CI job
