### PR TITLE
Fix AWS copilot example

### DIFF
--- a/examples/aws_copilot/copilot.py
+++ b/examples/aws_copilot/copilot.py
@@ -2,7 +2,7 @@ from opencopilot import OpenCopilot
 
 copilot = OpenCopilot(
     copilot_name="AWS CLI Copilot",
-    llm_model_name="gpt-3.5-turbo-16k", # You can also use gpt-4 for improved accuracy
+    llm="gpt-3.5-turbo-16k", # You can also use gpt-4 for improved accuracy
     prompt_file="prompt_template.txt"
 )
 


### PR DESCRIPTION
### Task / problem
AWS copilot example still has obsolete `llm_model_name` setting

### Changes made
`llm_model_name` -> `llm`

### Testing
Run AWS copilot