### PR TITLE
ENG-441 WIP frontend configuration interface

### DIFF
--- a/opencopilot/__init__.py
+++ b/opencopilot/__init__.py
@@ -1,1 +1,2 @@
 from .application import OpenCopilot as OpenCopilot
+from .settings import FrontendConf as FrontendConf

--- a/opencopilot/app.py
+++ b/opencopilot/app.py
@@ -150,7 +150,7 @@ def root():
 
 @app.get("/ui", include_in_schema=False, response_class=HTMLResponse)
 def ui(request: Request):
-    frontend_conf: FrontendConf = settings.get().FRONTEND_CONF or FrontendConf.default()
+    frontend_conf: FrontendConf = settings.get().FRONTEND_CONF
     template_params = {
         "request": request,
         "theme": frontend_conf.theme,

--- a/opencopilot/app.py
+++ b/opencopilot/app.py
@@ -11,6 +11,7 @@ from pydantic import BaseModel
 from starlette.middleware.cors import CORSMiddleware
 
 import opencopilot
+from opencopilot import FrontendConf
 from opencopilot import settings
 from opencopilot.logger import api_logger
 from opencopilot.routers import main_router
@@ -149,4 +150,13 @@ def root():
 
 @app.get("/ui", include_in_schema=False, response_class=HTMLResponse)
 def ui(request: Request):
-    return templates.TemplateResponse("index.html", {"request": request})
+    frontend_conf: FrontendConf = settings.get().FRONTEND_CONF or FrontendConf.default()
+    template_params = {
+        "request": request,
+        "theme": frontend_conf.theme,
+        "is_debug_enabled": "true" if frontend_conf.is_debug_enabled else "false",
+        "copilot_icon": frontend_conf.copilot_icon
+        if frontend_conf.copilot_icon
+        else "",
+    }
+    return templates.TemplateResponse("index.html", template_params)

--- a/opencopilot/application.py
+++ b/opencopilot/application.py
@@ -21,6 +21,7 @@ from opencopilot.domain.errors import LogsDirError
 from opencopilot.domain.errors import ModelError
 from opencopilot.logger import api_logger
 from opencopilot.repository.documents import split_documents_use_case
+from opencopilot.settings import FrontendConf
 from opencopilot.repository.conversation_history_repository import (
     ConversationHistoryRepositoryLocal,
 )
@@ -65,6 +66,7 @@ class OpenCopilot:
         helicone_rate_limit_policy: Optional[str] = "3;w=60;s=user",
         logs_dir: Optional[str] = "logs",
         log_level: Optional[Union[str, int]] = None,
+        frontend_conf: Optional[FrontendConf] = None,
     ):
         api_logger.set_log_level(log_level)
 
@@ -123,6 +125,7 @@ class OpenCopilot:
                 HELICONE_RATE_LIMIT_POLICY=helicone_rate_limit_policy,
                 TRACKING_ENABLED=tracking_enabled,
                 LOGS_DIR=logs_dir,
+                FRONTEND_CONF=frontend_conf,
             )
         )
 

--- a/opencopilot/application.py
+++ b/opencopilot/application.py
@@ -2,6 +2,7 @@ import os
 from datetime import timedelta
 from typing import Callable
 from typing import List
+from typing import Literal
 from typing import Optional
 from typing import Union
 
@@ -66,7 +67,9 @@ class OpenCopilot:
         helicone_rate_limit_policy: Optional[str] = "3;w=60;s=user",
         logs_dir: Optional[str] = "logs",
         log_level: Optional[Union[str, int]] = None,
-        frontend_conf: Optional[FrontendConf] = None,
+        ui_theme: Optional[Literal["light", "dark"]] = "light",
+        is_debug_enabled: Optional[bool] = True,
+        copilot_icon: Optional[str] = None,
     ):
         api_logger.set_log_level(log_level)
 
@@ -125,7 +128,11 @@ class OpenCopilot:
                 HELICONE_RATE_LIMIT_POLICY=helicone_rate_limit_policy,
                 TRACKING_ENABLED=tracking_enabled,
                 LOGS_DIR=logs_dir,
-                FRONTEND_CONF=frontend_conf,
+                FRONTEND_CONF=FrontendConf(
+                    theme=ui_theme,
+                    is_debug_enabled=is_debug_enabled,
+                    copilot_icon=copilot_icon,
+                ),
             )
         )
 

--- a/opencopilot/html/index.html
+++ b/opencopilot/html/index.html
@@ -4,15 +4,16 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>OpenCopilot UI</title>
-    <script src="https://unpkg.com/opencopilot-ui@0.0.7/opencopilot.js"></script>
+    <script src="https://unpkg.com/opencopilot-ui@0.0.8/opencopilot.js"></script>
 </head>
 <body>
     <div id="embedded" style="width: 100vw; height: 100vh;"></div>
     <script>
         OpenCopilot.initialize({
             elementId: "embedded", // The argument is the id of the element where the component should be rendered
-            theme: "light",
-            isDebug: true,
+            theme: "{{ theme }}",
+            isDebug: {{ is_debug_enabled }},
+            copilotIcon: "{{ copilot_icon }}" || undefined,
             // authToken: "", // If auth is enabled in backend need to input JWT here
         });
     </script>

--- a/opencopilot/settings.py
+++ b/opencopilot/settings.py
@@ -62,7 +62,7 @@ class Settings:
 
     HELICONE_BASE_URL = "https://oai.hconeai.com/v1"
 
-    FRONTEND_CONF: FrontendConf = None
+    FRONTEND_CONF: FrontendConf = FrontendConf.default()
 
     def __post_init__(self):
         if self.AUTH_TYPE is not None and (

--- a/opencopilot/settings.py
+++ b/opencopilot/settings.py
@@ -17,10 +17,7 @@ class FrontendConf:
 
     @staticmethod
     def default():
-        return FrontendConf(
-            is_debug_enabled=True,
-            copilot_icon=None
-        )
+        return FrontendConf(is_debug_enabled=True, copilot_icon=None, theme="light")
 
 
 @dataclass(frozen=False)
@@ -65,7 +62,7 @@ class Settings:
 
     HELICONE_BASE_URL = "https://oai.hconeai.com/v1"
 
-    FRONTEND_CONF: FrontendConf = FrontendConf.default()
+    FRONTEND_CONF: FrontendConf = None
 
     def __post_init__(self):
         if self.AUTH_TYPE is not None and (

--- a/opencopilot/settings.py
+++ b/opencopilot/settings.py
@@ -1,4 +1,5 @@
 from dataclasses import dataclass
+from typing import Literal
 from typing import Optional
 from typing import Union
 
@@ -6,6 +7,20 @@ from langchain.chat_models.base import BaseChatModel
 from langchain.embeddings.base import Embeddings
 
 from opencopilot.domain.chat.models.local import LocalLLM
+
+
+@dataclass(frozen=True)
+class FrontendConf:
+    theme: Optional[Literal["light", "dark"]] = "light"
+    is_debug_enabled: Optional[bool] = True
+    copilot_icon: Optional[str] = None
+
+    @staticmethod
+    def default():
+        return FrontendConf(
+            is_debug_enabled=True,
+            copilot_icon=None
+        )
 
 
 @dataclass(frozen=False)
@@ -49,6 +64,8 @@ class Settings:
     RESPONSE_TEMPLATE: Optional[str] = None
 
     HELICONE_BASE_URL = "https://oai.hconeai.com/v1"
+
+    FRONTEND_CONF: FrontendConf = FrontendConf.default()
 
     def __post_init__(self):
         if self.AUTH_TYPE is not None and (


### PR DESCRIPTION
### Task / problem
Make frontend configuration possible through the OpenCopilot constructor

Example usage:
```
from opencopilot import FrontendConf
from opencopilot import OpenCopilot

copilot = OpenCopilot(
    prompt_file="my_prompt.txt",
    # Is FrontendConf a good name? Open to suggestions, Optional value of course
    frontend_conf=FrontendConf(
        theme="light", # Optional str, "light" or "dark", defaults to "light"
        is_debug_enabled=True,   # Optional bool, default is True
        copilot_icon="https://url.com/image.jpg",   # Optional str of url or file path(?) for the copilot message in UI, default is None
    ),
)

copilot()
```



### Checklist

- [ ] If relevant, checked and updated the [docs repo](https://github.com/opencopilotdev/docs), [README](https://github.com/opencopilotdev/opencopilot/tree/README), and [examples](https://github.com/opencopilotdev/opencopilot/tree/main/examples)
