### PR TITLE
ENG-447 Set weaviate index name based on copilot name

### DIFF
--- a/opencopilot/application.py
+++ b/opencopilot/application.py
@@ -167,11 +167,7 @@ class OpenCopilot:
             or self.local_file_paths
             or self.data_urls
         ):
-            self.document_store = WeaviateDocumentStore(
-                copilot_name=self.copilot_name
-                if self.copilot_name != "default"
-                else None
-            )
+            self.document_store = WeaviateDocumentStore(copilot_name=self.copilot_name)
             if settings.get().WEAVIATE_URL:
                 logger.info("Connected to Weaviate vector DB.")
             else:
@@ -217,6 +213,14 @@ class OpenCopilot:
             len(self.data_urls),
         )
 
+        try:
+            app_conf = settings.AppConf(
+                copilot_name=self.copilot_name,
+                api_port=self.api_port,
+            )
+            app_conf.save()
+        except:
+            pass
         uvicorn.run(
             app,
             host=self.host,

--- a/opencopilot/application.py
+++ b/opencopilot/application.py
@@ -136,6 +136,7 @@ class OpenCopilot:
             )
         )
 
+        self.copilot_name = copilot_name
         self.llm = llm
         self.embedding_model = embedding_model
         self.host = host
@@ -166,7 +167,11 @@ class OpenCopilot:
             or self.local_file_paths
             or self.data_urls
         ):
-            self.document_store = WeaviateDocumentStore()
+            self.document_store = WeaviateDocumentStore(
+                copilot_name=self.copilot_name
+                if self.copilot_name != "default"
+                else None
+            )
             if settings.get().WEAVIATE_URL:
                 logger.info("Connected to Weaviate vector DB.")
             else:

--- a/opencopilot/cli.py
+++ b/opencopilot/cli.py
@@ -57,11 +57,14 @@ def main(ctx: typer.Context):
 @app.command(help="Chat with the Copilot. Example: chat 'Hello, who are you?'")
 def chat(message: str):
     print("Message:", message)
+    from opencopilot import settings
+
+    api_port = settings.get().API_PORT
     conversation_id = uuid.uuid4()
     while message:
         print("Response: ", end="", flush=True)
         cli_chat_use_case.conversation_stream(
-            base_url="http://0.0.0.0:3000",
+            base_url=f"http://0.0.0.0:{api_port}",
             conversation_id=conversation_id,
             message=message,
             stream=True,
@@ -122,8 +125,9 @@ def retrieve(
     validate_openai_api_key(openai_api_key)
 
     from opencopilot.repository.documents.document_store import WeaviateDocumentStore
+    from opencopilot import settings
 
-    document_store = WeaviateDocumentStore()
+    document_store = WeaviateDocumentStore(settings.get().COPILOT_NAME)
 
     if text is not None:
         where_filter = (

--- a/opencopilot/repository/documents/document_store.py
+++ b/opencopilot/repository/documents/document_store.py
@@ -167,7 +167,7 @@ class WeaviateDocumentStore(DocumentStore):
             for i in tqdm.tqdm(
                 range(0, int(len(documents) / batch_size) + 1), desc="Embedding.."
             ):
-                batch = documents[i * batch_size: (i + 1) * batch_size]
+                batch = documents[i * batch_size : (i + 1) * batch_size]
                 self.vector_store.add_documents(batch)
 
             self.embeddings.save_local_cache()
@@ -249,7 +249,7 @@ class WeaviateDocumentStore(DocumentStore):
     @staticmethod
     def get_index_name(copilot_name: str = None) -> str:
         default_name = "OPENCOPILOT"
-        if not copilot_name:
+        if not copilot_name or copilot_name == "default":
             return default_name
         formatted_name = "".join([i.upper() for i in copilot_name if i.isalpha()])
         return formatted_name or default_name

--- a/opencopilot/settings.py
+++ b/opencopilot/settings.py
@@ -1,4 +1,8 @@
+import json
+import os
 from dataclasses import dataclass
+from typing import Any
+from typing import Dict
 from typing import Literal
 from typing import Optional
 from typing import Union
@@ -7,6 +11,49 @@ from langchain.chat_models.base import BaseChatModel
 from langchain.embeddings.base import Embeddings
 
 from opencopilot.domain.chat.models.local import LocalLLM
+
+CONF_FILE_PATH = os.path.expanduser("~/.opencopilot/configuration.json")
+
+
+@dataclass(frozen=True)
+class AppConf:
+    copilot_name: str
+    api_port: int
+
+    def to_dict(self) -> Dict:
+        return {
+            "copilot_name": self.copilot_name,
+            "api_port": self.api_port,
+        }
+
+    @staticmethod
+    def from_dict(value: Dict) -> Optional[Any]:
+        try:
+            return AppConf(
+                copilot_name=value["copilot_name"],
+                api_port=value["api_port"],
+            )
+        except:
+            return None
+
+    @staticmethod
+    def get() -> Optional[Any]:
+        try:
+            if os.path.exists(CONF_FILE_PATH):
+                with open(CONF_FILE_PATH, "r") as file:
+                    value = json.load(file)
+                return AppConf.from_dict(value)
+        except:
+            pass
+        return None
+
+    def save(self):
+        try:
+            os.makedirs(os.path.dirname(CONF_FILE_PATH), exist_ok=True)
+            with open(CONF_FILE_PATH, "w") as file:
+                json.dump(self.to_dict(), file, indent=4)
+        except:
+            pass
 
 
 @dataclass(frozen=True)

--- a/opencopilot/settings.py
+++ b/opencopilot/settings.py
@@ -40,7 +40,7 @@ class AppConf:
     def get() -> Optional[Any]:
         try:
             if os.path.exists(CONF_FILE_PATH):
-                with open(CONF_FILE_PATH, "r") as file:
+                with open(CONF_FILE_PATH, "r", encoding="utf-8") as file:
                     value = json.load(file)
                 return AppConf.from_dict(value)
         except:
@@ -50,7 +50,7 @@ class AppConf:
     def save(self):
         try:
             os.makedirs(os.path.dirname(CONF_FILE_PATH), exist_ok=True)
-            with open(CONF_FILE_PATH, "w") as file:
+            with open(CONF_FILE_PATH, "w", encoding="utf-8") as file:
                 json.dump(self.to_dict(), file, indent=4)
         except:
             pass

--- a/opencopilot/utils/scripting.py
+++ b/opencopilot/utils/scripting.py
@@ -1,14 +1,17 @@
 import os
+from typing import Optional
+
 from opencopilot import settings
 from opencopilot.settings import Settings
 
 
 def set_default_settings(name: str = "script"):
+    app_conf: Optional[settings.AppConf] = settings.AppConf.get()
     settings.set(
         Settings(
-            COPILOT_NAME=name,
+            COPILOT_NAME=app_conf.copilot_name if app_conf else name,
             HOST="127.0.0.1",
-            API_PORT=3000,
+            API_PORT=app_conf.api_port if app_conf else 3000,
             ENVIRONMENT=name,
             ALLOWED_ORIGINS="*",
             WEAVIATE_URL="http://localhost:8080/",

--- a/tests/unit/repository/documents/test_document_store.py
+++ b/tests/unit/repository/documents/test_document_store.py
@@ -1,0 +1,20 @@
+from opencopilot.repository.documents.document_store import WeaviateDocumentStore as WS
+
+
+def test_index_name():
+    assert "OPENCOPILOT" == WS.get_index_name()
+    assert "OPENCOPILOT" == WS.get_index_name("OPENCOPILOT")
+
+    assert "OPENCOPILOT" == WS.get_index_name("opencopilot")
+    assert "OPENCOPILOT" == WS.get_index_name("Opencopilot")
+
+    assert "COPILOT" == WS.get_index_name("copilot")
+    assert "COPILOT" == WS.get_index_name("COPILOT")
+    assert "COPILOT" == WS.get_index_name("CoPilot")
+
+    assert "CUSTOMCOPILOT" == WS.get_index_name("Custom Copilot")
+    assert "CUSTOMCOPILOT" == WS.get_index_name("CUSTOM CO PILOT1 2 ")
+
+    assert "OPENCOPILOT" == WS.get_index_name("")
+    assert "OPENCOPILOT" == WS.get_index_name("222")
+    assert "OPENCOPILOT" == WS.get_index_name("222 -- 2313213121..,, ")


### PR DESCRIPTION
Index name is uppercase letters from copilot name and if copilot name not set or does not contain letters then defaults to "OPENCOPILOT".
Save latest copilot configuration (copilot name, api port) to ~/.opencopilot/configuration.json
CLI uses the conf file to get weaviate index name and API port

### Task / problem
We want to be able to run multiple copilots in one machine easily. With the current solution we use a hardcoded index name and the whole schema gets deleted, which makes it impossible to run multiple copilots with the same weaviate instance.

### Potential issues
- If we fail to save copilot configuration to ~/.opencopilot/configuration.json then CLI will not work (before if you were using any other api port than 3000 for example it didnt work either btw)


### Checklist

- [X] If relevant, checked and updated the [docs repo](https://github.com/opencopilotdev/docs), [README](https://github.com/opencopilotdev/opencopilot/blob/main/README.md), and [examples](https://github.com/opencopilotdev/opencopilot/tree/main/examples)
